### PR TITLE
These filters are necessary in order to work with earlier versions of WP and in the event that we are not using HPOS

### DIFF
--- a/app/Admin/Order/Actions.php
+++ b/app/Admin/Order/Actions.php
@@ -27,13 +27,13 @@ class Actions {
 
 		add_action( 'woocommerce_checkout_order_processed', array( __CLASS__, 'set_payment_method' ) );
 
-    if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
-     add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'add_selections_to_bulk_action' ) );
-     add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
-} else {
-		   add_filter( 'bulk_actions-edit-shop_order', array( __CLASS__, 'add_selections_to_bulk_action' ) );
-		   add_filter( 'handle_bulk_actions-edit-shop_order', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
-}
+    		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+     			add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'add_selections_to_bulk_action' ) );
+     			add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
+		} else {
+			add_filter( 'bulk_actions-edit-shop_order', array( __CLASS__, 'add_selections_to_bulk_action' ) );
+			add_filter( 'handle_bulk_actions-edit-shop_order', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
+		}
 		
 		add_action( 'admin_notices', array( __CLASS__, 'pdf_regeneration_bulk_action_admin_notices' ) );
 	}

--- a/app/Admin/Order/Actions.php
+++ b/app/Admin/Order/Actions.php
@@ -27,12 +27,14 @@ class Actions {
 
 		add_action( 'woocommerce_checkout_order_processed', array( __CLASS__, 'set_payment_method' ) );
 
-		// Adding in the event that HPOS is not used. Compatibility with earlier WP versions as well.
-		add_filter( 'bulk_actions-edit-shop_order', array( __CLASS__, 'add_selections_to_bulk_action' ) );
-		add_filter( 'handle_bulk_actions-edit-shop_order', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
-
-		add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'add_selections_to_bulk_action' ) );
-		add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
+    if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+     add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'add_selections_to_bulk_action' ) );
+     add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
+} else {
+		   add_filter( 'bulk_actions-edit-shop_order', array( __CLASS__, 'add_selections_to_bulk_action' ) );
+		   add_filter( 'handle_bulk_actions-edit-shop_order', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
+}
+		
 		add_action( 'admin_notices', array( __CLASS__, 'pdf_regeneration_bulk_action_admin_notices' ) );
 	}
 

--- a/app/Admin/Order/Actions.php
+++ b/app/Admin/Order/Actions.php
@@ -27,6 +27,10 @@ class Actions {
 
 		add_action( 'woocommerce_checkout_order_processed', array( __CLASS__, 'set_payment_method' ) );
 
+		// Adding in the event that HPOS is not used. Compatibility with earlier WP versions as well.
+		add_filter( 'bulk_actions-edit-shop_order', array( __CLASS__, 'add_selections_to_bulk_action' ) );
+		add_filter( 'handle_bulk_actions-edit-shop_order', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
+
 		add_filter( 'bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'add_selections_to_bulk_action' ) );
 		add_filter( 'handle_bulk_actions-woocommerce_page_wc-orders', array( __CLASS__, 'regenerate_order_pdfs_bulk_action_process' ), 10, 3 );
 		add_action( 'admin_notices', array( __CLASS__, 'pdf_regeneration_bulk_action_admin_notices' ) );


### PR DESCRIPTION
Tested on a website running the latest version of WP and Woocommerce as shown on this [issue](https://github.com/susameca/bulgarisation-for-woocommerce/issues/4)