### PR TITLE
Pigeon: Fix office/APS lookup using wrong city on name-search collisions

### DIFF
--- a/app/Shipping/Pigeon/Locker.php
+++ b/app/Shipping/Pigeon/Locker.php
@@ -63,7 +63,7 @@ class Locker {
 				$args[ 'error' ] = sprintf( __( '%s is not found in %s region.', 'bulgarisation-for-woocommerce' ), $raw_city, $state );
 			}
 		} else {
-			$lockers = self::$container[ Client::PIGEON_LOCKERS ]->get_lockers( $cities_data['cities'][ $cities_data['city_key'] ]['id'] );
+			$lockers = self::$container[ Client::PIGEON_LOCKERS ]->get_lockers( $cities_data['cities_search_names'][ $cities_data['city_key'] ]['id'] );
 
 			if ( empty( $lockers ) ) {
 				$lockers = [];

--- a/app/Shipping/Pigeon/Office.php
+++ b/app/Shipping/Pigeon/Office.php
@@ -63,7 +63,7 @@ class Office {
 				$args[ 'error' ] = sprintf( __( '%s is not found in %s region.', 'bulgarisation-for-woocommerce' ), $raw_city, $state );
 			}
 		} else {
-			$offices = self::$container[ Client::PIGEON_OFFICES ]->get_offices( $cities_data['cities'][ $cities_data['city_key'] ]['id'] );
+			$offices = self::$container[ Client::PIGEON_OFFICES ]->get_offices( $cities_data['cities_search_names'][ $cities_data['city_key'] ]['id'] );
 
 			if ( empty( $offices ) ) {
 				$offices = [];


### PR DESCRIPTION
The office and locker handlers read the selected city's ID from the unfiltered name-search results using city_key, which is an index into the region-filtered list. When the search returned other cities before the exact match (e.g. "Русе" returns Брусевци/Брусен/... first), the wrong ID was used and no offices/lockers were found. Resolve the ID from cities_search_names so the key and the array match.