### PR TITLE
Fix: defensive defaults for parcel.size and additionalServices.declar…

### DIFF
--- a/app/Admin/Speedy.php
+++ b/app/Admin/Speedy.php
@@ -95,6 +95,14 @@ class Speedy {
 									$parcel['size'] = $parcel['sizes'];
 									unset( $parcel['sizes'] );
 								}
+
+								if ( ! isset( $parcel['size'] ) || ! is_array( $parcel['size'] ) ) {
+									$parcel['size'] = array(
+										'depth'  => '',
+										'width'  => '',
+										'height' => '',
+									);
+								}
 							}
 						}
 					}
@@ -112,7 +120,20 @@ class Speedy {
 					if ( $theorder->get_payment_method() === 'cod' && !isset( $label_data['service']['additionalServices'] ) ) {
 						$label_data = self::fix_cod_data( $label_data, $theorder );
 					}
-					
+
+					if ( ! empty( $label_data ) ) {
+						if ( ! isset( $label_data['service']['additionalServices'] ) || ! is_array( $label_data['service']['additionalServices'] ) ) {
+							$label_data['service']['additionalServices'] = array();
+						}
+
+						if ( ! isset( $label_data['service']['additionalServices']['declaredValue'] ) ) {
+							$label_data['service']['additionalServices']['declaredValue'] = array(
+								'amount'  => '',
+								'fragile' => false,
+							);
+						}
+					}
+
 					wp_localize_script( 'woo-bg-js-admin', 'wooBg_speedy', array(
 						'label' => $label_data,
 						'shipmentStatus' => $shipment_status,


### PR DESCRIPTION
…edValue in Speedy metabox

The admin Vue app reads parcel.size.depth and
label.service.additionalServices.declaredValue unconditionally at mount/render time. For orders where the stored label data lacks these sub-keys, the whole Speedy Delivery metabox crashed and rendered empty:

- parcels generated for quantity > 1 contain only seqNo and weight (no size/sizes), so v-model="parcel.size.depth" threw 'Cannot read properties of undefined (reading depth)'
- additionalServices is only created via fix_cod_data() for COD payments, and declaredValue only when the shipment is fragile; card payments / non-fragile shipments had neither, so reading declaredValue threw at mounted()

Initialize both structures with empty defaults before passing the data to wp_localize_script().